### PR TITLE
Modifying script includes and API call to use HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <title>Ungentry</title>
 
 
-<link rel="stylesheet" href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/themes/smoothness/jquery-ui.css" type="text/css">
+<link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/themes/smoothness/jquery-ui.css" type="text/css">
 <link rel="stylesheet" href="./lib/bootstrap.min.css" type="text/css">
 <link rel="stylesheet" href="./lib/font-awesome.min.css" />
 <link rel="stylesheet" href="./lib/leaflet-0.7.3/leaflet.css" />
@@ -97,7 +97,7 @@
                 <li><div class="fb-share-button" data-href="http://codeforboston.github.io/ungentry/" data-type="button_count"></div></li>
                 <li><a></a></li>  
                 <li class="divider"></li>
-                <li><iframe src="http://ghbtns.com/github-btn.html?user=codeforboston&repo=ungentry&type=fork&count=true"
+                <li><iframe src="https://rawgit.com/mdo/github-buttons/master/github-btn.html?user=codeforboston&repo=ungentry&type=fork&count=true"
                   allowtransparency="true" frameborder="0" scrolling="0" width="95" height="20"></iframe></li>
               </ul>
    
@@ -146,13 +146,13 @@
 
 
 <!-- JQuery and JS for bootstrap -->
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
 <script src="./lib/bootstrap.min.js"></script>
 
  <script src="./lib/leaflet-0.7.3/leaflet.js"></script>
- <script src="http://rawgit.com/calvinmetcalf/leaflet-ajax/master/dist/leaflet.ajax.js"></script>
+ <script src="//rawgit.com/calvinmetcalf/leaflet-ajax/master/dist/leaflet.ajax.js"></script>
  <script src="./lib/topojson.v1.min.js"></script>
- <script src="http://maps.stamen.com/js/tile.stamen.js?v1.2.4"></script>
+ <script src="//stamen-maps.a.ssl.fastly.net/js/tile.stamen.js?v1.2.4"></script>
  <script src="./lib/L.Map.Sync.js"></script>
 
 <script src="./lib/Control.FullScreen.js"></script>
@@ -167,7 +167,7 @@
 <script src="./lib/underscore-min.js"></script>
 <script src="./lib/backbone-min.js"></script>
 
-<script src="http://code.jquery.com/ui/1.11.1/jquery-ui.js"></script>
+<script src="//code.jquery.com/ui/1.11.1/jquery-ui.js"></script>
 
 <script src="src/routes.js"></script>  
 <script src="src/script.js"></script>

--- a/src/script.js
+++ b/src/script.js
@@ -291,7 +291,7 @@ function bindAddress(){
 
     	$.ajax({
     		type: "GET",
-    		url: "http://nominatim.openstreetmap.org/search",
+    		url: "https://nominatim.openstreetmap.org/search",
     		data: { q: address, format: "json", polygon : "1" , addressdetails :"1" }
 		})
 		.done(function( data ) {


### PR DESCRIPTION
I use the [HTTPS Everywhere](https://www.eff.org/https-everywhere) extension in Chrome, which redirects Github Pages sites to their HTTPS equivalent. Since Ungentry was using `http://` includes in its script tags and a few other places, it wouldn't load for me unless I forced my browser back to HTTP.

I changed a couple of `src` and `link` tags to fix that problem, as well as the Nominatim API you were hitting.

Demo link: https://chrismetcalf.github.io/ungentry/