### PR TITLE
added ids to the columns of the maps, used bootstrap class names hidden-...

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,19 +89,19 @@
 </div>
 
  <div class="row maps">
-    <div  class="col-lg-3 col-md-3 col-xs-9 col-sm-9 map-wrapper">
-   	<div id="map0" class="map">
-   	  <h2 id="date">1990</h2>
-   	</div>  
+    <div id="map0_col" class="col-lg-3 col-md-3 col-xs-9 col-sm-9 map-wrapper">
+   	  <div id="map0" class="map">
+   	    <h2 id="date">1990</h2>
+   	  </div>  
     </div>
-    <div class="col-lg-3 col-md-3 hidden-xs hidden-sm  map-wrapper">
-   	<div id="map1" class="map" >
-   	  <h2>2000</h2>
-   	</div>  
+    <div id="map1_col" class="col-lg-3 col-md-3 hidden-xs hidden-sm  map-wrapper">
+   	  <div id="map1" class="map" >
+   	    <h2>2000</h2>
+   	  </div>  
     </div>
-    <div  class="col-lg-3 col-md-3 col-xs-3 col-md-3  hidden-xs hidden-sm  map-wrapper">
-   	<div id="map2" class="map">
-   	  <h2>2010</h2>
+    <div id="map2_col" class="col-lg-3 col-md-3 hidden-xs hidden-sm  map-wrapper">
+   	  <div id="map2" class="map">
+   	    <h2>2010</h2>
    	</div>
 
     </div>

--- a/src/script.js
+++ b/src/script.js
@@ -65,25 +65,49 @@ define([
 
     	init3ViewsMode(); // init the view with 3 maps
 
-    	$('#link_1900').click(function(event) {
+
+    	$('#link_1990').click(function(event) {
     	  event.preventDefault();
-    	  console.log('clicked 1900');
-    	  $('#map1').hide();
-    	  $('#map2').hide();
+    	  console.log('clicked 1990');
+          if($('#map0_col').hasClass('hidden-xs')===true){
+            $('#map0_col').removeClass('hidden-xs hidden-sm');  
+            $('#map0_col').addClass('col-xs-9 col-sm-9');  
+            $('#map1_col').removeClass('col-xs-9 col-sm-9');  
+            $('#map1_col').addClass('hidden-xs hidden-sm');  
+            $('#map2_col').removeClass('col-xs-9 col-sm-9');  
+            $('#map2_col').addClass('hidden-xs hidden-sm');  
+            
+          }
+          console.log('does 1990 have hidden-xs' + $('#map0').hasClass('hidden-xs'));
+          
     	});
     	$('#link_2000').click(function(event) {
     	  event.preventDefault();
     	  console.log('clicked 2000');
-    	  $('#map0').hide();
-    	  $('#map1').show();
-    	  $('#map2').hide();
+    	  if($('#map1_col').hasClass('hidden-xs')===true){
+            // $('#map0_col').removeClass('col-xs-9 col-sm-9  map-wrapper');  
+            $('#map0_col').removeClass('col-xs-9 col-sm-9');  
+            $('#map0_col').addClass('hidden-xs hidden-sm');  
+            $('#map1_col').removeClass('hidden-xs hidden-sm');  
+            $('#map1_col').addClass('col-xs-9 col-sm-9');  
+            $('#map2_col').removeClass('col-xs-9 col-sm-9');  
+            $('#map2_col').addClass('hidden-xs hidden-sm');  
+          }
+
+          console.log('does 2000 have hidden-xs' + $('#map1').hasClass('hidden-xs'));
     	});
     	$('#link_2010').click(function(event) {
     	  event.preventDefault();
     	  console.log('clicked 2010');
-    	  $('#map0').hide();
-    	  $('#map1').hide();
-    	  $('#map2').show();
+    	  if($('#map2_col').hasClass('hidden-xs')===true){
+            $('#map0_col').removeClass('col-xs-9 col-sm-9');  
+            $('#map0_col').addClass('hidden-xs hidden-sm');  
+            $('#map1_col').removeClass('col-xs-9 col-sm-9');  
+            $('#map1_col').addClass('hidden-xs hidden-sm');  
+            $('#map2_col').removeClass('hidden-xs hidden-sm');  
+            $('#map2_col').addClass('col-xs-9 col-sm-9');  
+          }
+          console.log('does 2010 have hidden-xs' + $('#map2').hasClass('hidden-xs'));
     	});
 
     }

--- a/src/style.css
+++ b/src/style.css
@@ -205,3 +205,6 @@ div.map > h2 {
     right:inherit;
 }
 
+.highlight{
+    background-color:yellow;
+}


### PR DESCRIPTION
Use boot strap hidden-sm and hidden-xs to hide map1_col and map2_col on smaller monitors.  When
you click links I toggle the classes for the map link the user clicks.  Two problems still outstanding, 1990 reloads page and maps 2000 and 2010 don't render when hidden.