### PR TITLE
Validate properties so all tracts are colored correctly

### DIFF
--- a/prospect/CensusLayer/js/CensusLayer.js
+++ b/prospect/CensusLayer/js/CensusLayer.js
@@ -313,7 +313,7 @@ define([
 
 					 var val = parseFloat(feature.properties[this._currentProperty]);
 
-					 if (val) {
+					 if (!NaN(val)) {
 						if ((typeof(highlight)!=="undefined") || feature.map_mouse_over==true) {
 					 		return {"fillColor": this._getColor(prop.serie,val) , "color" : "#f00" , "weight": 6 , "opacity" : 1.0,  "fillOpacity": 0.6};
 						} else {


### PR DESCRIPTION
To fix [issue 67](https://github.com/codeforboston/ungentry/issues/67). It makes sure all values are numbers when picking colors - if the value is not a number, the tract will be gray.