### PR TITLE
Inject values into unit templates.

### DIFF
--- a/src/iwindow.js
+++ b/src/iwindow.js
@@ -30,15 +30,15 @@ define(['jquery', 'underscore', "hoverTract", "variables", "colors"], function($
     }
 
     var formatters = {
-        "%": function(n) {
+        "{0}%": function(n) {
             return n.toFixed(2) + "%";
         },
 
-        "#": function(n) {
+        "#{0}": function(n) {
             return commaSeparate(n.toFixed(2));
         },
 
-        "$": function(n) {
+        "${0}": function(n) {
             return "$" + commaSeparate(n.toFixed(2));
         }
     };

--- a/src/legend.js
+++ b/src/legend.js
@@ -7,13 +7,13 @@ define(['jquery', 'underscore'], function($, _){
 	//  <i style="background: #fff;"></i> $265 - $756
 	//  <i style="background: #eee;"></i> $756 - $1000
 	// ...
-	var TEMPLATE = '<h4> <%= title %> </h4>'+
+	var TEMPLATE = _.template('<h4> <%= title %> </h4>'+
 									'<% _.each( data, function(entry){ %>'+
 									'<i style="background: <%= entry.color %>;"></i>'+
-									'<%= entry.unit %> <%= entry.min %> - '+
-									'<%= entry.unit %>  <%= entry.max %> '+
+									'<%= entry.unit.replace("{0}", entry.min) %> - '+
+									'<%= entry.unit.replace("{0}", entry.max) %>'+
 									'<br>'+
-									'<% }) %>';
+									'<% }) %>');
 
 	// Legend Data is an object with a title attribute, and a data attribute which is an array of legend entries as follows:
 
@@ -28,7 +28,7 @@ define(['jquery', 'underscore'], function($, _){
 	// ]
 	function render(event, legendData){
 		var $el = $(SELECTOR);
-		$el.html( _.template(TEMPLATE, legendData));
+		$el.html(TEMPLATE(legendData));
 
 	}
 


### PR DESCRIPTION
It looks like the unit string is formatted to allow a value to be inserted, which seems good since it works for both prefixes and suffixes, but the template wasn't doing the replacement.

For example, if the template string is `{0}%` and the value is `25`, the result should be `25%`.

I'm also precompiling the template, to render a bit faster.