### PR TITLE
Responsive CSS for mobile searchbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,14 +52,16 @@
         </button>
         <a class="navbar-brand" href="#"><h2>Ungentry</h2></a>
       </div>
-      <div id="navbar" class="navbar-collapse collapse" style="padding-right: 0px;">
+      <div id="navbar" class="navbar-collapse collapse">
 
 
         <form class="navbar-form navbar-right" role="search">
-          <div class="form-group">
+          <div class="input-group">
             <input type="text" id="address" class="form-control" placeholder="Search for addresses">
+            <span class="input-group-btn">
+              <button type="button" id="sendaddress" class="btn btn-default">Submit</button>
+            </span>
           </div>
-          <button type="button" id="sendaddress" class="btn btn-default">Submit</button>
         </form>
 
         <ul class="nav navbar-nav navbar-right">

--- a/src/style.css
+++ b/src/style.css
@@ -36,9 +36,15 @@ footer {
     margin-top: -10px;
 }
 
-.navbar-form {
-    padding-right: 0px;
+@media (min-width: 768px) {
+    .navbar-collapse {
+        padding-right: 0px;
+    }
+    .navbar-form {
+        padding-right: 0px;
+    }
 }
+
 /*
 .navbar-nav>li>a {
     padding-top: 10px;


### PR DESCRIPTION
Using Bootstrap's input group styling to fix overflow on mobile view. Moved desktop overrides into a media query. Screenshots:

> *Previous Mobile*
> ![screen shot 2015-06-16 at 8 34 34 pm](https://cloud.githubusercontent.com/assets/1848368/8197539/26966a1c-1467-11e5-9b86-087001e3849f.png)

***

> *Updated Mobile:*
> ![screen shot 2015-06-16 at 8 26 54 pm](https://cloud.githubusercontent.com/assets/1848368/8197436/3ee2ede4-1466-11e5-89c2-9c572ec872ec.png)

***

> *Updated Desktop:*
> ![screen shot 2015-06-16 at 8 27 04 pm](https://cloud.githubusercontent.com/assets/1848368/8197437/42733c34-1466-11e5-8b93-50029dd03e48.png)

